### PR TITLE
Stop GWCS bounding box override in imviz parser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,8 @@ Other Changes and Additions
 New Features
 ------------
 
+- Prevent image wrapping in Imviz with Roman L2 images with GWCS. [#2887]
+
 Cubeviz
 ^^^^^^^
 

--- a/jdaviz/configs/imviz/plugins/parsers.py
+++ b/jdaviz/configs/imviz/plugins/parsers.py
@@ -216,7 +216,7 @@ def _parse_image(app, file_obj, data_label, ext=None, parent=None):
             # NOTE: if extending this beyond GWCS, the mouseover logic
             # for outside_*_bounding_box should also be updated.
             data.coords._orig_bounding_box = data.coords.bounding_box
-            data.coords.bounding_box = None
+
         if not data.meta.get(_wcs_only_label, False):
             data_label = app.return_data_label(data_label, alt_name="image_data")
 


### PR DESCRIPTION
Minor changes for https://github.com/spacetelescope/jdaviz/pull/2887 in preparation for fixes from https://github.com/spacetelescope/gwcs/pull/498.